### PR TITLE
add scene and proxy as attributes

### DIFF
--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,0 +1,27 @@
+from compas_ui.app import App
+
+print('App initialized:',App.initialized())
+
+a = App()
+
+print('App initialized:',App.initialized())
+
+b = App()
+
+assert a == b
+
+a.session['test'] = 1
+
+a.session.filepath = 'temp/test1.json'
+a.session['test'] = 1
+a.session.record()
+a.session.save()
+
+a.session.filepath = 'temp/test2.json'
+a.session['test'] = 2
+a.session.record()
+a.session.save()
+
+a.session.filepath = 'temp/test3.json'
+a.session.undo()
+a.session.save()

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,11 +1,6 @@
 from compas_ui.app import App
 
-print('App initialized:',App.initialized())
-
 a = App()
-
-print('App initialized:',App.initialized())
-
 b = App()
 
 assert a == b

--- a/src/compas_ui/app.py
+++ b/src/compas_ui/app.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from .session import Session
+
+
+class App(object):
+    """App singleton.
+
+    Parameters
+    ----------
+    scene : :class:`compas_ui.scene.Scene`, optional
+        The compas_ui scene object.
+    proxy : Union[:class:`compas_cloud.Proxy`, :class:`compas.rpc.Proxy`], optional
+        The compas rpc or compas_cloud Proxy object.
+
+    Attributes
+    ----------
+    scene : :class:`compas_ui.scene.Scene`
+        The compas_ui scene object.
+    proxy : Union[:class:`compas_cloud.Proxy`, :class:`compas.rpc.Proxy`]
+        The compas rpc or compas_cloud Proxy object.
+    session : :class:`compas_ui.session.Session`
+        The compas_ui session object.
+
+    """
+
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            self = super(App, cls).__new__(cls)
+            self._initialized = False
+            cls._instance = self
+        return cls._instance
+
+    def __init__(self, scene=None, proxy=None):
+        if self._initialized:
+            return
+        self.scene = scene
+        self.proxy = proxy
+        self.session = Session()
+        self._initialized = True
+
+    @classmethod
+    def initialized(cls):
+        return cls._instance is not None and cls._instance._initialized

--- a/src/compas_ui/app.py
+++ b/src/compas_ui/app.py
@@ -2,9 +2,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from .singleton import Singleton
 from .session import Session
 
 
+@Singleton
 class App(object):
     """App singleton.
 
@@ -26,23 +28,7 @@ class App(object):
 
     """
 
-    _instance = None
-
-    def __new__(cls, *args, **kwargs):
-        if not cls._instance:
-            self = super(App, cls).__new__(cls)
-            self._initialized = False
-            cls._instance = self
-        return cls._instance
-
     def __init__(self, scene=None, proxy=None):
-        if self._initialized:
-            return
         self.scene = scene
         self.proxy = proxy
         self.session = Session()
-        self._initialized = True
-
-    @classmethod
-    def initialized(cls):
-        return cls._instance is not None and cls._instance._initialized

--- a/src/compas_ui/session.py
+++ b/src/compas_ui/session.py
@@ -25,7 +25,7 @@ atexit.register(autosave)
 
 
 class Session(object):
-    """Session singleton.
+    """The Session class that tracks states of an app.
 
     Parameters
     ----------
@@ -37,15 +37,21 @@ class Session(object):
         Defaults to the directory containing the script running the session.
     extension : str, optional
         The extension used for saving the session to disk.
+        Defaults to 'json'.
     autosave : bool, optional
         If True, automatically save the session to file at interpreter shutdown.
-    scene : :class:`compas_ui.scene.Scene`, optional
-        The compas scene object to be saved to the session.
-    proxy : Union[:class:`compas_cloud.Proxy`, :class:`compas.rpc.Proxy`], optional
-        The compas rpc or compas_cloud Proxy object.
+        Defaults to False.
 
     Attributes
     ----------
+    name : str
+        Name of the session.
+    directory : str
+        The directory where the session should be saved.
+    extension : str
+        The extension used for saving the session to disk.
+    autosave : bool
+        If True, automatically save the session to file at interpreter shutdown.
     dataschema : schema.Schema
         The schema of the session data.
     historyschema : schema.Schema
@@ -57,18 +63,7 @@ class Session(object):
 
     """
 
-    _instance = None
-    initialized = False
-
-    def __new__(cls, *args, **kwargs):
-        if not cls._instance:
-            self = super(Session, cls).__new__(cls)
-            cls._instance = self
-        return cls._instance
-
-    def __init__(self, name=None, directory=None, extension='json', autosave=False, scene=None, proxy=None):
-        if self.__class__.initialized:
-            return
+    def __init__(self, name=None, directory=None, extension='json', autosave=False):
         self._history = deque()
         self._current = 0
         self.data = {}
@@ -76,9 +71,6 @@ class Session(object):
         self.name = name or self.__class__.__name__
         self.extension = extension
         self.autosave = autosave
-        self.scene = scene
-        self.proxy = proxy
-        self.__class__.initialized = True
 
     def __str__(self):
         return json_dumps(self.data, pretty=True)

--- a/src/compas_ui/session.py
+++ b/src/compas_ui/session.py
@@ -12,6 +12,7 @@ from compas.data import json_load
 from compas.data import json_loads
 from compas.data import json_dump
 from compas.data import json_dumps
+from .singleton import Singleton
 
 
 def autosave():
@@ -24,8 +25,9 @@ def autosave():
 atexit.register(autosave)
 
 
+@Singleton
 class Session(object):
-    """The Session class that tracks states of an app.
+    """The Session singleton that tracks states of an app.
 
     Parameters
     ----------

--- a/src/compas_ui/session.py
+++ b/src/compas_ui/session.py
@@ -39,6 +39,10 @@ class Session(object):
         The extension used for saving the session to disk.
     autosave : bool, optional
         If True, automatically save the session to file at interpreter shutdown.
+    scene : :class:`compas_ui.scene.Scene`, optional
+        The compas scene object to be saved to the session.
+    proxy : Union[:class:`compas_cloud.Proxy`, :class:`compas.rpc.Proxy`], optional
+        The compas rpc or compas_cloud Proxy object.
 
     Attributes
     ----------
@@ -109,7 +113,7 @@ class Session(object):
     @property
     def filepath(self):
         return os.path.join(self.directory, self.filename)
-    
+
     @filepath.setter
     def filepath(self, filepath):
         dirname, basename = os.path.split(filepath)

--- a/src/compas_ui/singleton.py
+++ b/src/compas_ui/singleton.py
@@ -1,0 +1,10 @@
+def Singleton(cls):
+    """Decorator for creating a singleton class."""
+    instances = {}
+
+    def get_instance(*args, **kwargs):
+        if cls not in instances:
+            instances[cls] = cls(*args, **kwargs)
+        return instances[cls]
+
+    return get_instance


### PR DESCRIPTION
- Adding Scene and Proxy (can be either compas_cloud or rpc) as attributes.
- Move attributes assign to `__init__` so it can be linted by pylance