### PR TITLE
allow import exception

### DIFF
--- a/src/compas_ui/ui.py
+++ b/src/compas_ui/ui.py
@@ -35,19 +35,22 @@ from compas_ui.session import Session
 from compas_ui.scene import Scene
 from compas_ui.controller import Controller
 
-from compas_ui.rhino.forms import AboutForm
-from compas_ui.rhino.forms import CondaEnvsForm
+try:
+    from compas_ui.rhino.forms import AboutForm
+    from compas_ui.rhino.forms import CondaEnvsForm
 
-# from compas_ui.rhino.forms import ErrorForm
-from compas_ui.rhino.forms import FileForm
-from compas_ui.rhino.forms import FolderForm
+    # from compas_ui.rhino.forms import ErrorForm
+    from compas_ui.rhino.forms import FileForm
+    from compas_ui.rhino.forms import FolderForm
 
-# from compas_ui.rhino.forms import InfoForm
-# from compas_ui.rhino.forms import MeshDataForm
-from compas_ui.rhino.forms import SceneObjectsForm
-from compas_ui.rhino.forms import SearchPathsForm
-from compas_ui.rhino.forms import SettingsForm
-from compas_ui.rhino.forms import SplashForm
+    # from compas_ui.rhino.forms import InfoForm
+    # from compas_ui.rhino.forms import MeshDataForm
+    from compas_ui.rhino.forms import SceneObjectsForm
+    from compas_ui.rhino.forms import SearchPathsForm
+    from compas_ui.rhino.forms import SettingsForm
+    from compas_ui.rhino.forms import SplashForm
+except ImportError:
+    pass
 
 
 class UI(Singleton):


### PR DESCRIPTION
Temporarily allow rhino form import exception so ui can at least run outside of Rhino for faster development. We should properly implement a context setup later for Forms in same way of artists and objects.