### PR TITLE
add use_tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `compas_ui.rhino.forms.SearchPathsForm`.
 * Added default controller for all non-system commands.
 * Added `active_object` to `scene`.
+* Added `use_tab` option to `compas_ui.rhino.forms.SettingsForm`.
 
 ### Changed
 

--- a/scripts/test_settings_with_tab.py
+++ b/scripts/test_settings_with_tab.py
@@ -1,0 +1,25 @@
+from compas.colors import Color
+from compas_ui.rhino.forms import SettingsForm
+
+SETTINGS = {
+    "plugin_a": {
+        "color": Color.blue(),
+        "int": 1,
+        "float": 0.1
+    },
+    "plugin_b": {
+        "bool": True,
+        "text": "text"
+    },
+    "asdfaf": True
+}
+
+# Create form with tabs on first level
+form = SettingsForm(SETTINGS, title="With Tabs", use_tab=True)
+if form.show():
+    print(form.settings)
+
+# Create form without tabs
+form = SettingsForm(SETTINGS, title="Without Tabs")
+if form.show():
+    print(form.settings)

--- a/scripts/test_settings_with_tab.py
+++ b/scripts/test_settings_with_tab.py
@@ -10,8 +10,7 @@ SETTINGS = {
     "plugin_b": {
         "bool": True,
         "text": "text"
-    },
-    "asdfaf": True
+    }
 }
 
 # Create form with tabs on first level

--- a/src/compas_ui/rhino/forms/settings.py
+++ b/src/compas_ui/rhino/forms/settings.py
@@ -80,11 +80,12 @@ class CustomCell(Eto.Forms.CustomCell):
 
 
 class SettingsForm(Eto.Forms.Dialog[bool]):
-    def __init__(self, settings, title="Settings", width=500, height=500):
+    def __init__(self, settings, title="Settings", width=500, height=500, use_tab=False):
         self._settings = None
         self._names = None
         self._values = None
         self.settings = settings
+        self.use_tab = use_tab
 
         self.Title = title
         self.Padding = Eto.Drawing.Padding(0)
@@ -92,13 +93,30 @@ class SettingsForm(Eto.Forms.Dialog[bool]):
         self.MinimumSize = Eto.Drawing.Size(0.5 * width, 0.5 * height)
         self.ClientSize = Eto.Drawing.Size(width, height)
 
-        self.table = Eto.Forms.TreeGridView()
         layout = Eto.Forms.DynamicLayout()
         layout.BeginVertical(
             Eto.Drawing.Padding(0, 0, 0, 0), Eto.Drawing.Size(0, 0), True, True
         )
-        self.map_tree(self.table)
-        layout.AddRow(self.table)
+
+        if self.use_tab:
+
+            control = Eto.Forms.TabControl()
+            control.TabPosition = Eto.Forms.DockPosition.Top
+
+            self.tables = {}
+            for key, settings in self.settings.items():
+                if not isinstance(settings, dict):
+                    raise TypeError("When use_tab is True the firt level of the settings value must be all dicts.")
+                tab = Eto.Forms.TabPage(Text=key)
+                control.Pages.Add(tab)
+                table = self.map_tree(settings)
+                tab.Content = self.tables[key] = table
+            layout.AddRow(control)
+
+        else:
+            self.table = self.map_tree(settings)
+            layout.AddRow(self.table)
+
         layout.EndVertical()
         layout.BeginVertical(
             Eto.Drawing.Padding(12, 18, 12, 24), Eto.Drawing.Size(6, 0), False, False
@@ -108,8 +126,9 @@ class SettingsForm(Eto.Forms.Dialog[bool]):
 
         self.Content = layout
 
-    def map_tree(self, table):
+    def map_tree(self, settings):
         """Create the items for the form."""
+        table = Eto.Forms.TreeGridView()
         treecollection = Eto.Forms.TreeGridItemCollection()
         table.ShowHeader = True
         column = Eto.Forms.GridColumn()
@@ -138,8 +157,9 @@ class SettingsForm(Eto.Forms.Dialog[bool]):
                     add_items(item.Children, value)
                 parent.Add(item)
 
-        add_items(treecollection, self.settings)
+        add_items(treecollection, settings)
         table.DataStore = treecollection
+        return table
 
     @property
     def ok(self):
@@ -171,7 +191,6 @@ class SettingsForm(Eto.Forms.Dialog[bool]):
 
     def on_ok(self, sender, event):
         try:
-
             def set_value(items, setting):
                 for item in items:
                     key = item.GetValue(0)
@@ -180,8 +199,11 @@ class SettingsForm(Eto.Forms.Dialog[bool]):
                         set_value(item.Children, setting[key])
                     else:
                         setting[key] = value
-
-            set_value(self.table.DataStore, self.settings)
+            if not self.use_tab:
+                set_value(self.table.DataStore, self.settings)
+            else:
+                for key in self.settings:
+                    set_value(self.tables[key].DataStore, self.settings[key])
 
         except Exception as e:
             print(e)


### PR DESCRIPTION
Added tabular option for `SettingsForm`. See: scripts/test_settings_with_tab.py
<img width="378" alt="image" src="https://user-images.githubusercontent.com/17893605/188886845-3b8ae4b6-bfb8-4ff4-90f5-4c47c444ad35.png">
