### PR TITLE
allow key editing in form to support default attribute edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added default controller for all non-system commands.
 * Added `active_object` to `scene`.
 * Added `use_tab` option to `compas_ui.rhino.forms.SettingsForm`.
+* Added `allow_edit_key` option to `compas_ui.rhino.forms.SettingsForm`.
+* Added `Edit Default Attributes` button to `compas_ui.rhino.forms.MeshDataForm`.
 
 ### Changed
 

--- a/scripts/test_data_form.py
+++ b/scripts/test_data_form.py
@@ -1,0 +1,6 @@
+from compas.datastructures import Mesh
+from compas_ui.rhino.forms import MeshDataForm
+import compas
+
+mesh = Mesh.from_obj(compas.get('faces.obj'))
+MeshDataForm(mesh).show()

--- a/src/compas_ui/rhino/forms/meshdata.py
+++ b/src/compas_ui/rhino/forms/meshdata.py
@@ -8,6 +8,7 @@ import Rhino
 import Rhino.UI
 import Eto.Drawing
 import Eto.Forms
+from .settings import SettingsForm
 
 
 class MeshDataForm(Eto.Forms.Dialog[bool]):
@@ -163,11 +164,30 @@ class Page(object):
         self.table = Table(self.cols, self.rows)
         self.widget = Eto.Forms.TabPage()
         self.widget.Text = title
+        self.layout = Eto.Forms.DynamicLayout()
         if self.names:
             # replace this by a dynamic layout
             # with the first row an overview of the default attribute values
             # and second row the data table
-            self.widget.Content = self.table.widget
+            self.layout.BeginVertical(
+                Eto.Drawing.Padding(0, 0, 0, 0), Eto.Drawing.Size(0, 0), True, True
+            )
+            self.layout.AddRow(self.table.widget)
+            self.layout.EndVertical()
+            self.layout.BeginVertical(
+                Eto.Drawing.Padding(0, 6, 0, 6), Eto.Drawing.Size(6, 0), False, False
+            )
+            button = Eto.Forms.Button(Text="Edit Default Attributes")
+            button.Click += self.edit_default_attributes
+            self.layout.AddRow(button, None)
+            self.layout.EndVertical()
+            self.widget.Content = self.layout
+
+    def edit_default_attributes(self, sender, event):
+        form = SettingsForm(self.defaults, "Default Attributes", allow_edit_key=True)
+        if form.show():
+            self.defaults.clear()
+            self.defaults.update(form.settings)
 
     @property
     def names(self):


### PR DESCRIPTION
Make settings form to support key editing, adding and deleting. In order to support function like default attributes editing.
There are few interaction behavior to figure out, let's discuss tomorrow in person : )

<img width="611" alt="image" src="https://user-images.githubusercontent.com/17893605/189156528-6ef575b7-69f6-4428-8336-4d7d9d648cd9.png">
