### PR TITLE
add undo redo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `rhino_undo` and `skip_rhino_undo` decorators for rhino commands.
+
 ### Changed
 
 ### Removed

--- a/src/compas_ui/rhino/ui/COMPAS/dev/COMPAS_load_cmd.py
+++ b/src/compas_ui/rhino/ui/COMPAS/dev/COMPAS_load_cmd.py
@@ -5,6 +5,7 @@ __commandname__ = "COMPAS_load"
 
 
 @UI.error()
+@UI.rhino_undo(__commandname__)
 def RunCommand(is_interactive):
 
     ui = UI()

--- a/src/compas_ui/rhino/ui/COMPAS/dev/COMPAS_mesh_create_cmd.py
+++ b/src/compas_ui/rhino/ui/COMPAS/dev/COMPAS_mesh_create_cmd.py
@@ -5,12 +5,11 @@ __commandname__ = "COMPAS_mesh_create"
 
 
 @UI.error()
+@UI.rhino_undo(__commandname__)
 def RunCommand(is_interactive):
 
     ui = UI()
-
     ui.controller.mesh_create()
-    ui.record()
 
 
 if __name__ == "__main__":

--- a/src/compas_ui/rhino/ui/COMPAS/dev/COMPAS_scene_clear_cmd.py
+++ b/src/compas_ui/rhino/ui/COMPAS/dev/COMPAS_scene_clear_cmd.py
@@ -5,6 +5,7 @@ __commandname__ = "COMPAS_scene_clear"
 
 
 @UI.error()
+@UI.rhino_undo(__commandname__)
 def RunCommand(is_interactive):
 
     ui = UI()

--- a/src/compas_ui/rhino/ui/COMPAS/dev/COMPAS_scene_objects_cmd.py
+++ b/src/compas_ui/rhino/ui/COMPAS/dev/COMPAS_scene_objects_cmd.py
@@ -5,6 +5,7 @@ __commandname__ = "COMPAS_scene_objects"
 
 
 @UI.error()
+@UI.rhino_undo(__commandname__)
 def RunCommand(is_interactive):
 
     ui = UI()

--- a/src/compas_ui/rhino/ui/COMPAS/dev/COMPAS_scene_update_cmd.py
+++ b/src/compas_ui/rhino/ui/COMPAS/dev/COMPAS_scene_update_cmd.py
@@ -5,6 +5,7 @@ __commandname__ = "COMPAS_scene_update"
 
 
 @UI.error()
+@UI.rhino_undo(__commandname__)
 def RunCommand(is_interactive):
 
     ui = UI()

--- a/src/compas_ui/rhino/ui/COMPAS/dev/COMPAS_settings_cmd.py
+++ b/src/compas_ui/rhino/ui/COMPAS/dev/COMPAS_settings_cmd.py
@@ -6,6 +6,7 @@ __commandname__ = "COMPAS_settings"
 
 
 @UI.error()
+@UI.rhino_undo(__commandname__)
 def RunCommand(is_interactive):
 
     ui = UI()
@@ -13,6 +14,8 @@ def RunCommand(is_interactive):
     form = SettingsForm(ui.registry, use_tab=True)
     if form.show():
         ui.registry.update(form.settings)
+
+    ui.record()
 
 
 if __name__ == "__main__":

--- a/src/compas_ui/rhino/undo.py
+++ b/src/compas_ui/rhino/undo.py
@@ -1,0 +1,52 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+from compas_ui.ui import UI
+from functools import wraps
+import scriptcontext as sc
+
+
+def rhino_undo(command_name):
+
+    def undo_redo_handler(sender, e):
+        ui = UI()
+        if e.Tag == "undo":
+            ui.undo()
+            e.Document.AddCustomUndoEvent(command_name, undo_redo_handler, "redo")
+        if e.Tag == "redo":
+            ui.redo()
+            e.Document.AddCustomUndoEvent(command_name, undo_redo_handler, "undo")
+
+    def outer(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            sc.doc.EndUndoRecord(sc.doc.CurrentUndoRecordSerialNumber)
+            undoRecord = sc.doc.BeginUndoRecord(command_name)
+            if undoRecord == 0:
+                print("undo record did not start")
+
+            print("undo record", undoRecord)
+
+            func(*args, **kwargs)
+
+            sc.doc.AddCustomUndoEvent(command_name, undo_redo_handler, "undo")
+
+            if undoRecord > 0:
+                sc.doc.EndUndoRecord(undoRecord)
+
+        return wrapper
+
+    return outer
+
+
+def skip_rhino_undo():
+
+    def outer(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            sc.doc.EndUndoRecord(sc.doc.CurrentUndoRecordSerialNumber)
+            func(*args, **kwargs)
+        return wrapper
+
+    return outer

--- a/src/compas_ui/rhino/undo.py
+++ b/src/compas_ui/rhino/undo.py
@@ -26,8 +26,6 @@ def rhino_undo(command_name):
             if undoRecord == 0:
                 print("undo record did not start")
 
-            print("undo record", undoRecord)
-
             func(*args, **kwargs)
 
             sc.doc.AddCustomUndoEvent(command_name, undo_redo_handler, "undo")

--- a/src/compas_ui/ui.py
+++ b/src/compas_ui/ui.py
@@ -198,6 +198,48 @@ class UI(Singleton):
             self.proxy.shutdown()
 
     # ========================================================================
+    # Undo/Redo
+    # ========================================================================
+
+    @staticmethod
+    def rhino_undo(*args, **kwargs):
+        """Decorator to bind Rhino undo redo shortkeys.
+
+        Parameters
+        ----------
+        *args : list
+            ???
+        **kwargs : dict
+            ???
+
+        Returns
+        -------
+        callable
+
+        """
+        from .rhino.undo import rhino_undo
+        return rhino_undo(*args, **kwargs)
+
+    @staticmethod
+    def skip_rhino_undo(*args, **kwargs):
+        """Decorator to skip Rhino undo redo recording.
+
+        Parameters
+        ----------
+        *args : list
+            ???
+        **kwargs : dict
+            ???
+
+        Returns
+        -------
+        callable
+
+        """
+        from .rhino.undo import skip_rhino_undo
+        return skip_rhino_undo(*args, **kwargs)
+
+    # ========================================================================
     # Environments
     # ========================================================================
 

--- a/src/compas_ui/ui.py
+++ b/src/compas_ui/ui.py
@@ -113,6 +113,7 @@ class UI(Singleton):
         state["session"] = self.session.data
         state["scene"] = self.scene.state
         state["settings"] = self.settings
+        state["registry"] = self.registry
         return state
 
     @state.setter
@@ -120,6 +121,7 @@ class UI(Singleton):
         self.session.data = state["session"]
         self.scene.state = state["scene"]
         self.settings = state["settings"]
+        self.registry = state["registry"]
 
     # ========================================================================
     # Init
@@ -320,9 +322,9 @@ class UI(Singleton):
 
         """
         form = SceneObjectsForm(self.scene)
-        if form.show():
-            self.scene.update()
-            self.record()
+        form.show()
+        self.scene.update()
+        self.record()
 
     # ========================================================================
     # State


### PR DESCRIPTION
We need to test this a bit more thoroughly with more complicated operations in FoFin first. 
In principle all commands that triggers `ui.record()` should be added this decorator. Otherwise the would the rhino undo/redo stack would start to mismatch with compas_ui's , which gonna cause weird behaviours.