### PR TITLE
install all plugins through compas_ui

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
-flake8
-black
 attrs >=17.4
+black
 bump2version >=1.0.1
 check-manifest >=0.36
 compas_invocations
 doc8
+flake8
 graphviz
 invoke >=0.14
 ipykernel
@@ -13,10 +13,9 @@ isort
 m2r2
 nbsphinx
 pydocstyle
-pytest <7.1
-sphinx_compas_theme >=0.15.18
-matplotlib
+pytest
 sphinx
+sphinx_compas_theme >=0.15.18
 twine
 wheel
 -e .

--- a/src/compas_ui/rhino/install.py
+++ b/src/compas_ui/rhino/install.py
@@ -1,24 +1,16 @@
 import os
-import sys
-
-from shutil import copyfile
-from subprocess import call
-
-import compas
 from compas.plugins import plugin
-import compas_rhino
-
-from compas_rhino.install_plugin import install_plugin
-import pkg_resources
-from pkg_resources import DistributionNotFound, VersionConflict
+from .install_plugin import install_plugin
+from .install_plugin import clean_up
+from .install_plugin import get_package_plugins
 
 
 HERE = os.path.dirname(__file__)
-
-
-def get_version_from_args():
-    args = compas_rhino.INSTALLATION_ARGUMENTS
-    return compas_rhino._check_rhino_version(args.version)
+PLUGINS = [
+    'COMPAS{6c18fcab-3ae5-4b03-b515-d33d8078b977}',
+    'FoFin{18a65b9c-1a08-43ef-a1fd-ef458f0a1fa0}',
+    'IGS2{aa509b0a-64d6-4a3f-a0c3-028565cf3174}'
+]
 
 
 @plugin(category="install", tryfirst=True)
@@ -26,112 +18,23 @@ def after_rhino_install(installed_packages):
     if "compas_cloud" not in installed_packages:
         return []
 
-    version = get_version_from_args()
-    install(version)
+    # Clean up old plugins and broken links
+    clean_up(PLUGINS)
 
-    return [("compas_ui", "COMPAS UI installed", True)]
+    # Install plugins from each package
+    results = []
+    for package in installed_packages:
+        plugin_paths = get_package_plugins(package)
+        for plugin_path in plugin_paths:
+            message = install_plugin(plugin_path, generate_rui=True)
+            results.append((package, message, True))
+
+    return results
 
 
 @plugin(category="install", tryfirst=True)
 def installable_rhino_packages():
     return ["compas_ui"]
-
-
-def check_folders(plugin_name, version="7.0"):
-    try:
-        print("Checking that the plugin folder exists")
-        plugin_name = "COMPAS"
-        plugin_path = os.path.join(HERE, "ui", plugin_name)
-        if not os.path.isdir(plugin_path):
-            raise Exception("Cannot find the plugin: {}".format(plugin_path))
-        print(plugin_path, "Exists")
-        print("PASSED.\n")
-
-        print("Checking that the plugin folder contains a dev folder")
-        plugin_path = os.path.abspath(plugin_path)
-        plugin_dev = os.path.join(plugin_path, "dev")
-        if not os.path.isdir(plugin_dev):
-            raise Exception("Cannot find the dev folder at: {}".format(plugin_dev))
-        print(plugin_dev, "Exists")
-        print("PASSED.\n")
-
-        print("Checking that the dev folder contains config.json")
-        plugin_config = os.path.join(plugin_dev, "config.json")
-        if not os.path.isfile(plugin_config):
-            raise Exception("Cannot find the config file at: {}".format(plugin_config))
-        print(plugin_config, "Exists")
-        print("PASSED.\n")
-
-        print("Checking that the Rhino scripts folder exists")
-        rhino_scripts_path = compas_rhino._get_rhino_scripts_path(version)
-        if not os.path.isdir(rhino_scripts_path):
-            raise Exception("Cannot find the Rhino scripts folder at: {}".format(rhino_scripts_path))
-        print(rhino_scripts_path, "Exists")
-        print("PASSED.\n")
-
-        print("Checking that user has write access to the Rhino scripts folder")
-        if not os.access(rhino_scripts_path, os.W_OK):
-            raise Exception(
-                "User does not have write access to the Rhino scripts folder at: {}".format(rhino_scripts_path)
-            )
-        print("User has write access to the Rhino scripts folder")
-        print("PASSED.\n")
-
-        print("\n All checks passed.")
-        return True
-
-    except Exception as e:
-        print("FAILED:")
-        print(e)
-        return False
-
-
-def check_dependencies(requirements_path=None):
-    try:
-        dependencies = []
-        with open(
-            requirements_path or os.path.join(HERE, "..", "..", "..", "requirements.txt"),
-            "r",
-        ) as f:
-            for line in f.readlines():
-                if line.startswith("#"):
-                    continue
-                dependencies.append(line.rstrip())
-
-        print("Required packages:")
-        print(dependencies)
-
-        pkg_resources.require(dependencies)
-
-        print("\n All checks passed.")
-        return True
-    except (DistributionNotFound, VersionConflict) as e:
-        print("FAILED:")
-        print(e)
-        return False
-
-
-def install(version="7.0"):
-    plugin_name = "COMPAS"
-    plugin_path = os.path.join(HERE, "ui", plugin_name)
-    if not os.path.isdir(plugin_path):
-        raise Exception("Cannot find the plugin: {}".format(plugin_path))
-
-    plugin_path = os.path.abspath(plugin_path)
-    plugin_dev = os.path.join(plugin_path, "dev")
-
-    install_plugin(plugin_path)
-
-    if compas.WINDOWS:
-        plugin_ruipy = os.path.join(plugin_dev, "rui.py")
-        plugin_rui = "{}.rui".format(plugin_name)
-        python_plugins_path = compas_rhino._get_rhino_pythonplugins_path(version)
-
-        call(sys.executable + " " + plugin_ruipy, shell=True)
-        copyfile(
-            os.path.join(plugin_dev, plugin_rui),
-            os.path.join(python_plugins_path, "..", "..", "UI", plugin_rui),
-        )
 
 
 if __name__ == "__main__":

--- a/src/compas_ui/rhino/install.py
+++ b/src/compas_ui/rhino/install.py
@@ -7,9 +7,9 @@ from .install_plugin import get_package_plugins
 
 HERE = os.path.dirname(__file__)
 PLUGINS = [
-    'COMPAS{6c18fcab-3ae5-4b03-b515-d33d8078b977}',
-    'FoFin{18a65b9c-1a08-43ef-a1fd-ef458f0a1fa0}',
-    'IGS2{aa509b0a-64d6-4a3f-a0c3-028565cf3174}'
+    "COMPAS{6c18fcab-3ae5-4b03-b515-d33d8078b977}",
+    "FoFin{18a65b9c-1a08-43ef-a1fd-ef458f0a1fa0}",
+    "IGS2{aa509b0a-64d6-4a3f-a0c3-028565cf3174}",
 ]
 
 

--- a/src/compas_ui/rhino/install_plugin.py
+++ b/src/compas_ui/rhino/install_plugin.py
@@ -18,6 +18,7 @@ def get_version_from_args():
     args = compas_rhino.INSTALLATION_ARGUMENTS
     return compas_rhino._check_rhino_version(args.version)
 
+
 def get_package_plugins(package_name):
 
     plugin_paths = []
@@ -36,10 +37,8 @@ def get_package_plugins(package_name):
     return plugin_paths
 
 
-
 def install_plugin(plugin, generate_rui=False):
-    """Install a Rhino Python Command Plugin.
-    """
+    """Install a Rhino Python Command Plugin."""
     if not os.path.isdir(plugin):
         raise Exception("Cannot find the plugin: {}".format(plugin))
 
@@ -97,7 +96,7 @@ def install_plugin(plugin, generate_rui=False):
             os.path.join(plugin_dev, plugin_rui),
             os.path.join(python_plugins_path, "..", "..", "UI", plugin_rui),
         )
-    
+
     return "python plugin {} installed".format(plugin_fullname)
 
 

--- a/src/compas_ui/rhino/install_plugin.py
+++ b/src/compas_ui/rhino/install_plugin.py
@@ -1,0 +1,144 @@
+import os
+import imp
+
+import compas
+import compas_rhino
+
+from compas._os import create_symlinks
+from compas._os import remove_symlinks
+
+import sys
+
+from shutil import copyfile
+from subprocess import call
+from importlib import import_module
+
+
+def get_version_from_args():
+    args = compas_rhino.INSTALLATION_ARGUMENTS
+    return compas_rhino._check_rhino_version(args.version)
+
+def get_package_plugins(package_name):
+
+    plugin_paths = []
+
+    package = import_module(package_name)
+    package_dir = os.path.dirname(package.__file__)
+    package_plugins_path = os.path.join(package_dir, "rhino", "ui")
+    if os.path.exists(package_plugins_path):
+        for plugin_name in os.listdir(package_plugins_path):
+            plugin_path = os.path.join(package_plugins_path, plugin_name)
+            plugin_path = os.path.abspath(plugin_path)
+            plugin_dev = os.path.join(plugin_path, "dev")
+            if os.path.exists(plugin_dev):
+                plugin_paths.append(plugin_path)
+
+    return plugin_paths
+
+
+
+def install_plugin(plugin, generate_rui=False):
+    """Install a Rhino Python Command Plugin.
+    """
+    if not os.path.isdir(plugin):
+        raise Exception("Cannot find the plugin: {}".format(plugin))
+
+    version = get_version_from_args()
+
+    plugin_dir = os.path.abspath(plugin)
+
+    # -----------------------------
+    # proceed with the installation
+    # -----------------------------
+
+    plugin_path, plugin_name = os.path.split(plugin_dir)
+    plugin_path = plugin_path or os.getcwd()
+
+    plugin_dev = os.path.join(plugin_dir, "dev")
+
+    if not os.path.isdir(plugin_dev):
+        raise Exception("The plugin does not contain a dev folder.")
+
+    plugin_info = os.path.join(plugin_dev, "__plugin__.py")
+
+    if not os.path.isfile(plugin_info):
+        raise Exception("The plugin does not contain plugin info.")
+
+    __plugin__ = imp.load_source("__plugin__", plugin_info)
+
+    if not __plugin__.id:
+        raise Exception("Plugin id is not set.")
+
+    if not __plugin__.title:
+        raise Exception("Plugin title is not set.")
+
+    plugin_fullname = "{}{}".format(__plugin__.title, __plugin__.id)
+
+    python_plugins_path = compas_rhino._get_rhino_pythonplugins_path(version)
+
+    if not os.path.exists(python_plugins_path):
+        os.mkdir(python_plugins_path)
+
+    source = plugin_dir
+    destination = os.path.join(python_plugins_path, plugin_fullname)
+
+    # print("\nInstalling PlugIn {} to Rhino PythonPlugIns.".format(plugin_name))
+
+    remove_symlinks([destination])
+    create_symlinks([(source, destination)])
+
+    # print("\nPlugIn {} Installed.".format(plugin_name))
+
+    if compas.WINDOWS and generate_rui:
+        plugin_ruipy = os.path.join(plugin_dev, "rui.py")
+        plugin_rui = "{}.rui".format(plugin_name)
+        call(sys.executable + " " + plugin_ruipy, shell=True)
+        copyfile(
+            os.path.join(plugin_dev, plugin_rui),
+            os.path.join(python_plugins_path, "..", "..", "UI", plugin_rui),
+        )
+    
+    return "python plugin {} installed".format(plugin_fullname)
+
+
+def clean_up(plugins):
+
+    version = get_version_from_args()
+
+    # Clean up the plugin directory
+    symlinks_to_remove = []
+    python_plugins_path = compas_rhino._get_rhino_pythonplugins_path(version)
+    for name in os.listdir(python_plugins_path):
+        path = os.path.join(python_plugins_path, name)
+        if os.path.islink(path):
+            # Check if the symlink is pointing to a valid location
+            if not os.path.exists(path):
+                symlinks_to_remove.append(dict(name=name, link=path))
+
+            # Check if the symlink is one of the plugins we are installing
+            if name in plugins:
+                symlinks_to_remove.append(dict(name=name, link=path))
+
+    symlinks_removed = []
+    symlinks_unremoved = []
+
+    if symlinks_to_remove:
+        symlinks = [link["link"] for link in symlinks_to_remove]
+        removal_results = remove_symlinks(symlinks)
+        for uninstall_data, success in zip(symlinks_to_remove, removal_results):
+            if success:
+                symlinks_removed.append(uninstall_data["name"])
+            else:
+                symlinks_unremoved.append(uninstall_data["name"])
+
+    if symlinks_removed:
+        print("\nThe following package symlinks were removed:\n")
+        for name in symlinks_removed:
+            print("   {}".format(name.ljust(20)))
+
+    if symlinks_unremoved:
+        print("\nThe following package symlinks could not be removed:\n")
+        for name in symlinks_unremoved:
+            print("   {}".format(name.ljust(20)))
+
+    print("\nClean up complete.\n")


### PR DESCRIPTION
@brgcode How about this:
We handle all plugin installations through compas_ui, which means:
1. Clean up the python plugin folder, remove existing listed plugins and broken links.
2. Go through installed packages, check if they have a plugin, if yes, install it, including rui generation.

This is all done centrally in the `after_rhino_install` of `compas_ui`, other plugins like FoFin, IGS2 etc will no longer need to define it individually, all they need is indicating `installable_rhino_packages`, The result would looks like this:
```
(compas-dev) D:\Github\compas>python -m compas_rhino.install

Installing COMPAS packages to Rhino 7.0 scripts folder:
C:\Users\leoch\AppData\Roaming\McNeel\Rhinoceros\7.0\scripts

   compas               OK
   compas_assembly      OK
   compas_cloud         OK
   compas_fd            OK
   compas_fofin         OK
   compas_ghpython      OK
   compas_igs2          OK
   compas_rhino         OK
   compas_ui            OK
   compas_bootstrapper  OK

Running post-installation steps...


The following package symlinks were removed:

   COMPAS{6c18fcab-3ae5-4b03-b515-d33d8078b977}
   FoFin{18a65b9c-1a08-43ef-a1fd-ef458f0a1fa0}
   IGS2{aa509b0a-64d6-4a3f-a0c3-028565cf3174}

Clean up complete.

   compas_fofin         OK: python plugin FoFin{18a65b9c-1a08-43ef-a1fd-ef458f0a1fa0} installed
   compas_igs2          OK: python plugin IGS2{aa509b0a-64d6-4a3f-a0c3-028565cf3174} installed
   compas_ui            OK: python plugin COMPAS{6c18fcab-3ae5-4b03-b515-d33d8078b977} installed
   compas_ghpython      OK: Installed 0 GH User Objects

Install completed.
```

Let me know what you think